### PR TITLE
composer update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.260.0",
+            "version": "3.260.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "25a14f63cc927d72adad3cc24d6bcdadfe6e0fc7"
+                "reference": "964653acda337343e64344426fa609cf1df930e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/25a14f63cc927d72adad3cc24d6bcdadfe6e0fc7",
-                "reference": "25a14f63cc927d72adad3cc24d6bcdadfe6e0fc7",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/964653acda337343e64344426fa609cf1df930e1",
+                "reference": "964653acda337343e64344426fa609cf1df930e1",
                 "shasum": ""
             },
             "require": {
@@ -146,9 +146,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.260.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.260.1"
             },
-            "time": "2023-02-21T20:26:17+00:00"
+            "time": "2023-02-22T19:23:27+00:00"
         },
         {
             "name": "brick/math",
@@ -1198,7 +1198,7 @@
         },
         {
             "name": "illuminate/broadcasting",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/broadcasting.git",
@@ -1256,7 +1256,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1309,7 +1309,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1371,16 +1371,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "6607201ee327ab8f04034a2ceb8125d70c05860e"
+                "reference": "0168d0e44ea0c4fe5451fe08cde7049b9e9f9741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/6607201ee327ab8f04034a2ceb8125d70c05860e",
-                "reference": "6607201ee327ab8f04034a2ceb8125d70c05860e",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/0168d0e44ea0c4fe5451fe08cde7049b9e9f9741",
+                "reference": "0168d0e44ea0c4fe5451fe08cde7049b9e9f9741",
                 "shasum": ""
             },
             "require": {
@@ -1422,11 +1422,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-02-21T18:19:28+00:00"
+            "time": "2023-02-22T11:32:27+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1472,7 +1472,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1520,7 +1520,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1584,7 +1584,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1635,7 +1635,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1683,7 +1683,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
@@ -1753,7 +1753,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1808,7 +1808,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1872,7 +1872,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
@@ -1932,7 +1932,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1978,7 +1978,7 @@
         },
         {
             "name": "illuminate/mail",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/mail.git",
@@ -2039,7 +2039,7 @@
         },
         {
             "name": "illuminate/notifications",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/notifications.git",
@@ -2097,7 +2097,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -2145,7 +2145,7 @@
         },
         {
             "name": "illuminate/queue",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
@@ -2212,7 +2212,7 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
@@ -2269,7 +2269,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -2340,7 +2340,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -2399,7 +2399,7 @@
         },
         {
             "name": "illuminate/view",
-            "version": "v9.52.2",
+            "version": "v9.52.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",


### PR DESCRIPTION
- Upgrading aws/aws-sdk-php (3.260.0 => 3.260.1)
- Upgrading illuminate/broadcasting (v9.52.2 => v9.52.4)
- Upgrading illuminate/bus (v9.52.2 => v9.52.4)
- Upgrading illuminate/cache (v9.52.2 => v9.52.4)
- Upgrading illuminate/collections (v9.52.2 => v9.52.4)
- Upgrading illuminate/conditionable (v9.52.2 => v9.52.4)
- Upgrading illuminate/config (v9.52.2 => v9.52.4)
- Upgrading illuminate/console (v9.52.2 => v9.52.4)
- Upgrading illuminate/container (v9.52.2 => v9.52.4)
- Upgrading illuminate/contracts (v9.52.2 => v9.52.4)
- Upgrading illuminate/database (v9.52.2 => v9.52.4)
- Upgrading illuminate/events (v9.52.2 => v9.52.4)
- Upgrading illuminate/filesystem (v9.52.2 => v9.52.4)
- Upgrading illuminate/http (v9.52.2 => v9.52.4)
- Upgrading illuminate/macroable (v9.52.2 => v9.52.4)
- Upgrading illuminate/mail (v9.52.2 => v9.52.4)
- Upgrading illuminate/notifications (v9.52.2 => v9.52.4)
- Upgrading illuminate/pipeline (v9.52.2 => v9.52.4)
- Upgrading illuminate/queue (v9.52.2 => v9.52.4)
- Upgrading illuminate/session (v9.52.2 => v9.52.4)
- Upgrading illuminate/support (v9.52.2 => v9.52.4)
- Upgrading illuminate/testing (v9.52.2 => v9.52.4)
- Upgrading illuminate/view (v9.52.2 => v9.52.4)