### PR TITLE
composer update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.263.3",
+            "version": "3.263.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "be23e6b278e9a3f4a5b15394f85e9c3f54c9dd7e"
+                "reference": "08e2f243243a9fcdd8909d596e46f81d8c72cb60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/be23e6b278e9a3f4a5b15394f85e9c3f54c9dd7e",
-                "reference": "be23e6b278e9a3f4a5b15394f85e9c3f54c9dd7e",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/08e2f243243a9fcdd8909d596e46f81d8c72cb60",
+                "reference": "08e2f243243a9fcdd8909d596e46f81d8c72cb60",
                 "shasum": ""
             },
             "require": {
@@ -150,9 +150,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.263.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.263.4"
             },
-            "time": "2023-04-04T18:24:59+00:00"
+            "time": "2023-04-05T18:21:54+00:00"
         },
         {
             "name": "brick/math",
@@ -983,7 +983,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1036,7 +1036,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1098,7 +1098,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1153,7 +1153,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1199,7 +1199,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1247,7 +1247,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1311,7 +1311,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1362,7 +1362,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1410,7 +1410,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1465,7 +1465,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1529,7 +1529,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
@@ -1589,7 +1589,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1635,7 +1635,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1683,7 +1683,7 @@
         },
         {
             "name": "illuminate/process",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/process.git",
@@ -1734,7 +1734,7 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
@@ -1791,7 +1791,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -1862,7 +1862,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -1921,16 +1921,16 @@
         },
         {
             "name": "illuminate/view",
-            "version": "v10.6.1",
+            "version": "v10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
-                "reference": "a003192eee0b05cd14718475adf5294ebb084d96"
+                "reference": "81c2d4e35774714ccd53f3b8fba2afe7ee093609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/view/zipball/a003192eee0b05cd14718475adf5294ebb084d96",
-                "reference": "a003192eee0b05cd14718475adf5294ebb084d96",
+                "url": "https://api.github.com/repos/illuminate/view/zipball/81c2d4e35774714ccd53f3b8fba2afe7ee093609",
+                "reference": "81c2d4e35774714ccd53f3b8fba2afe7ee093609",
                 "shasum": ""
             },
             "require": {
@@ -1971,7 +1971,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-03-13T01:22:02+00:00"
+            "time": "2023-04-04T21:48:21+00:00"
         },
         {
             "name": "jolicode/jolinotif",


### PR DESCRIPTION
- Upgrading aws/aws-sdk-php (3.263.3 => 3.263.4)
- Upgrading illuminate/bus (v10.6.1 => v10.6.2)
- Upgrading illuminate/cache (v10.6.1 => v10.6.2)
- Upgrading illuminate/collections (v10.6.1 => v10.6.2)
- Upgrading illuminate/conditionable (v10.6.1 => v10.6.2)
- Upgrading illuminate/config (v10.6.1 => v10.6.2)
- Upgrading illuminate/console (v10.6.1 => v10.6.2)
- Upgrading illuminate/container (v10.6.1 => v10.6.2)
- Upgrading illuminate/contracts (v10.6.1 => v10.6.2)
- Upgrading illuminate/events (v10.6.1 => v10.6.2)
- Upgrading illuminate/filesystem (v10.6.1 => v10.6.2)
- Upgrading illuminate/http (v10.6.1 => v10.6.2)
- Upgrading illuminate/macroable (v10.6.1 => v10.6.2)
- Upgrading illuminate/pipeline (v10.6.1 => v10.6.2)
- Upgrading illuminate/process (v10.6.1 => v10.6.2)
- Upgrading illuminate/session (v10.6.1 => v10.6.2)
- Upgrading illuminate/support (v10.6.1 => v10.6.2)
- Upgrading illuminate/testing (v10.6.1 => v10.6.2)
- Upgrading illuminate/view (v10.6.1 => v10.6.2)